### PR TITLE
Fully upgrading to Swift 4

### DIFF
--- a/PADockerfile
+++ b/PADockerfile
@@ -1,1 +1,1 @@
-RUN apt-get -y update && apt-get -y install libcurl4-openssl-dev && wget http://download.newrelic.com/agent_sdk/nr_agent_sdk-v0.16.2.0-beta.x86_64.tar.gz -O /tmp/nr.tgz && tar --strip-components=1 -zxvf /tmp/nr.tgz && ldconfig
+RUN apt-get -y update && apt-get -y install libcurl4-openssl-dev && wget http://download.newrelic.com/agent_sdk/nr_agent_sdk-v0.16.2.0-beta.x86_64.tar.gz -O /tmp/nr.tgz && pushd . && cd /usr/local && tar --strip-components=1 -zxvf /tmp/nr.tgz && ldconfig && popd

--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,5 @@
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
 //
 //  Package.swift
 //  Perfect-NewRelic-Linux
@@ -16,8 +18,24 @@
 //
 //===----------------------------------------------------------------------===//
 //
+
 import PackageDescription
 
 let package = Package(
-    name: "PerfectNewRelic"
+    name: "PerfectNewRelic",
+    products: [
+        .library(
+            name: "PerfectNewRelic",
+            targets: ["PerfectNewRelic"]),
+    ],
+    dependencies: [
+    ],
+    targets: [
+        .target(
+            name: "PerfectNewRelic",
+            dependencies: []),
+        .testTarget(
+            name: "PerfectNewRelicTests",
+            dependencies: ["PerfectNewRelic"]),
+    ]
 )

--- a/Sources/PerfectNewRelic/PerfectNewRelic.swift
+++ b/Sources/PerfectNewRelic/PerfectNewRelic.swift
@@ -17,11 +17,9 @@
 //===----------------------------------------------------------------------===//
 //
 
-#if os(Linux)
-import SwiftGlibc
-#else
-import Darwin
-#endif
+import Foundation
+import Dispatch
+import Glibc
 
 /// NewRelic Swift Agent SDK
 public class NewRelic {

--- a/Tests/PerfectNewRelicTests/PerfectNewRelicTests.swift
+++ b/Tests/PerfectNewRelicTests/PerfectNewRelicTests.swift
@@ -18,7 +18,9 @@
 //
 
 import XCTest
-import SwiftGlibc
+import Foundation
+import Dispatch
+import Glibc
 @testable import PerfectNewRelic
 
 class PerfectNewRelicTests: XCTestCase {


### PR DESCRIPTION
Note: On Swift 4, Linux MUST explicitly declare `import Dispatch`
otherwise it will yield “undefined reference to
'_NSConcreteStackBlock’”, etc.